### PR TITLE
Updated title

### DIFF
--- a/components/staking-hero.js
+++ b/components/staking-hero.js
@@ -74,7 +74,7 @@ const StakingHero = () => {
       <section className="staking_hero" id="home">
         <div className="container">
           <div className="staking_hero__headline">
-            <h1>Earn ETH rewards for staking PLR token</h1>
+            <h1>Earn WETH rewards for staking PLR token</h1>
           </div>
           {/* Current Stats */}
           <div className="staking_hero__stats">


### PR DESCRIPTION
* ETH replaced with WETH in PLR staking page

![Screenshot 2024-03-04 at 5 15 28 PM](https://github.com/pillarwallet/pillar-dao-landing/assets/82652040/a4431350-0ada-442a-96d5-2116f281540f)
